### PR TITLE
Limit capacity for events

### DIFF
--- a/lib/bulk-apply-applications.js
+++ b/lib/bulk-apply-applications.js
@@ -58,7 +58,6 @@ function bulkApplyApplications (args, callback) {
   function validateTicketsAvailable (done) {
     seneca.act({role: plugin, cmd: 'searchTickets', query: {sessionId: applications[0].sessionId, deleted: 0}}, function (err, tickets) {
       if (err) return done(err);
-      var ticketsAvailable = true;
       _.each(applications, function(application, cb) {
         var available = _.find(tickets, function(ticket) {
           var ticketAvailable = (ticket.quantity - ticket.totalApplications) > 0;

--- a/lib/bulk-apply-applications.js
+++ b/lib/bulk-apply-applications.js
@@ -21,6 +21,7 @@ function bulkApplyApplications (args, callback) {
   async.waterfall([
     loadValidationData,
     validateRequest,
+    validateTicketsAvailable,
     loadEvent,
     saveApplications,
     generateEmailContent
@@ -50,6 +51,21 @@ function bulkApplyApplications (args, callback) {
         return userPermission.name === 'ticketing-admin';
       });
       if (!isTicketingAdmin) return done(new Error('You must be a ticketing admin of this Dojo to update applications.'));
+      return done();
+    });
+  }
+
+  function validateTicketsAvailable (done) {
+    seneca.act({role: plugin, cmd: 'searchTickets', query: {sessionId: applications[0].sessionId, deleted: 0}}, function (err, tickets) {
+      if (err) return done(err);
+      var ticketsAvailable = true;
+      _.each(applications, function(application, cb) {
+        var available = _.find(tickets, function(ticket) {
+          var ticketAvailable = (ticket.quantity - ticket.totalApplications) > 0;
+          return (ticket.id == application.ticketId) && ticketAvailable;
+        });
+        if(!available) return done(new Error('There are no tickets of that type available at this time.'));
+      });
       return done();
     });
   }

--- a/lib/save-ticket.js
+++ b/lib/save-ticket.js
@@ -1,13 +1,15 @@
 'use strict';
 
+var _ = require('lodash');
+
 function saveTicket (args, callback) {
   var seneca = this;
   var ENTITY_NS = 'cd/tickets';
   var ticketEntity = seneca.make$(ENTITY_NS);
 
-  var ticket = args.ticket;
-  delete ticket['totalApplications'];
-  delete ticket['approvedApplications'];
+  var ticket = _.pick(args.ticket, function(key) {
+    return ['id', 'sessionId', 'name', 'type', 'quantity', 'deleted', 'invites'].indexOf(key) !== -1;
+  });
   if (!ticket) return callback(null, {error: 'args.ticket is empty'});
   ticketEntity.save$(ticket, callback);
 }

--- a/lib/save-ticket.js
+++ b/lib/save-ticket.js
@@ -6,6 +6,8 @@ function saveTicket (args, callback) {
   var ticketEntity = seneca.make$(ENTITY_NS);
 
   var ticket = args.ticket;
+  delete ticket['totalApplications'];
+  delete ticket['approvedApplications'];
   if (!ticket) return callback(null, {error: 'args.ticket is empty'});
   ticketEntity.save$(ticket, callback);
 }

--- a/lib/search-tickets.js
+++ b/lib/search-tickets.js
@@ -1,11 +1,43 @@
 'use strict';
 
+var async = require('async');
+
 function searchTickets (args, callback) {
   var seneca = this;
   var ticketsEntity = seneca.make$('cd/tickets');
-  var query = args.query || {};
-  if (!query.limit$) query.limit$ = 'NULL';
-  ticketsEntity.list$(query, callback);
+  var plugin = args.role;
+
+  async.waterfall([
+    loadTickets,
+    getNumberOfApplications,
+    getNumberOfApprovedApplications
+  ], callback);
+
+  function loadTickets (done) {
+    var query = args.query || {};
+    if (!query.limit$) query.limit$ = 'NULL';
+    ticketsEntity.list$(query, done);
+  }
+
+  function getNumberOfApplications (tickets, done) {
+    async.map(tickets, function (ticket, cb) {
+      seneca.act({role: plugin, cmd: 'searchApplications', query: {ticketId: ticket.id, deleted: 0}}, function(err, applications) {
+        if (err) return cb(err);
+        ticket.totalApplications = applications.length;
+        cb(null,ticket);
+      });
+    }, done);
+  }
+
+  function getNumberOfApprovedApplications (tickets, done) {
+    async.map(tickets, function (ticket, cb) {
+      seneca.act({role: plugin, cmd: 'searchApplications', query: {ticketId: ticket.id, deleted: 0, status: "approved"}}, function(err, applications) {
+        if (err) return cb(err);
+        ticket.approvedApplications = applications.length;
+        cb(null,ticket);
+      });
+    }, done);
+  }
 }
 
 module.exports = searchTickets;


### PR DESCRIPTION
This adds service side validation to resolve CoderDojo/community-platform#778. It ensures that applications cannot be made once the event has reached capacity.

UI changes accompany this at CoderDojo/cp-zen-platform#731.

*Note: This commit makes it impossible to add a ticket if the number of applications matches event capacity. As discussed in option 3 of the issue mentioned above.*