### PR TITLE
Add sanitize-html to clean event description field

### DIFF
--- a/lib/save-event.js
+++ b/lib/save-event.js
@@ -3,6 +3,23 @@
 var async = require('async');
 var _ = require('lodash');
 var moment = require('moment');
+var sanitizeHtml = require('sanitize-html');
+
+// TODO: think about sharing these settings if using sanitizeHtml elsewhere
+var SANITIZE_HTML_OPTIONS = {
+  allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
+  allowedAttributes: _.assign({}, sanitizeHtml.defaults.allowedAttributes, {
+    /**
+     * Allowing everything here since within ckeditor you have the option of setting the following:
+     *
+     *   * styles such as border, width, and height.
+     *   * alt text
+     *
+     * However ng-bind-html strips the style tag, so you won't actually see custom styling.
+     */
+    img: ['*']
+  })
+};
 
 function saveEvent (args, callback) {
   var seneca = this;
@@ -41,7 +58,15 @@ function saveEvent (args, callback) {
       country: eventInfo.country,
       createdAt: new Date(),
       createdBy: eventInfo.userId,
-      description: eventInfo.description,
+
+      /**
+       * The description field contains user generated html.
+       * We'd like to sanitize it to strip out script tags and other bad things.
+       * See https://github.com/punkave/sanitize-html#what-are-the-default-options for a list
+       * sanitizeHtml's default settings.
+       */
+      description: sanitizeHtml(eventInfo.description, SANITIZE_HTML_OPTIONS),
+
       dojoId: eventInfo.dojoId,
       name: eventInfo.name,
       position: eventInfo.position,

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "async": "0.9.2",
-    "cp-permissions-plugin": "git://github.com/CoderDojo/cp-permissions-plugin#1.0.2",
     "cp-logs-lib": "git://github.com/CoderDojo/cp-logs-lib#1.1.0",
+    "cp-permissions-plugin": "git://github.com/CoderDojo/cp-permissions-plugin#1.0.2",
     "ejs": "1.0.0",
     "js-yaml": "3.2.7",
     "json2csv": "2.11.0",
@@ -39,6 +39,7 @@
     "newrelic": "1.21.1",
     "pg": "4.4.0",
     "postgrator": "2.5.0",
+    "sanitize-html": "1.14.1",
     "seneca": "1.4.0",
     "seneca-postgresql-store": "1.1.3",
     "shortid": "2.2.2",


### PR DESCRIPTION
Now that the description field consists of user generated html,
we'd like to sanitize it before saving it to the database. This
helps strip out any malicious user input that sneaks by ckeditor.

See https://github.com/punkave/sanitize-html for more information.

before:
```
const x = "<b>hi!</b><script>alert('hey');</script>";
```

after:
```
const y = sanitizeHtml(x); // "<b>hi!</b>
```
