### PR TITLE
Fix translation for event's session cancellation

### DIFF
--- a/lib/cancel-session.js
+++ b/lib/cancel-session.js
@@ -12,7 +12,7 @@ function cancelSession (args, callback) {
   var sessionId = session.id;
   var locality = args.locality || 'en_US';
   var eventDateFormat = 'Do MMMM YY';
-  var emailSubject = session.emailSubject || 'has been cancelled';
+  var emailSubject = session.emailSubject || '%1$s has been cancelled';
   delete session.emailSubject;
   var sessionData;
   var eventData;
@@ -89,7 +89,6 @@ function cancelSession (args, callback) {
   }
 
   function emailSessionAttendees (done) {
-    emailSubject = sessionData.name + ' ' + emailSubject;
     var eventDate;
     var firstDate = _.first(eventData.dates);
     var lastDate = _.last(eventData.dates);
@@ -110,6 +109,7 @@ function cancelSession (args, callback) {
             to: profile.email || null,
             code: 'session-cancelled-',
             subject: emailSubject,
+            subjectVariables: sessionData.name,
             locality: locality,
             content: {
               applicantName: profile.name,
@@ -134,11 +134,11 @@ function cancelSession (args, callback) {
 
           function emailParents (cb) {
             if (!_.isEmpty(profile.parents)) {
-              async.eachSeries(profile.parents, function (parent, cb) {
+              async.eachSeries(profile.parents, function (parent, sCb) {
                 seneca.act({role: 'cd-users', cmd: 'load', id: parent, user: user}, function (err, parentUser) {
-                  if (err) return cb(err);
+                  if (err) return sCb(err);
                   payload.to = parentUser.email;
-                  seneca.act({role: 'cd-dojos', cmd: 'send_email', payload: payload}, cb);
+                  seneca.act({role: 'cd-dojos', cmd: 'send_email', payload: payload}, sCb);
                 });
               }, cb);
             } else {

--- a/lib/save-event.js
+++ b/lib/save-event.js
@@ -91,6 +91,7 @@ function saveEvent (args, callback) {
           var sessionFound = _.find(eventInfo.sessions, function (session) {
             return existingSession.id === session.id;
           });
+          // The whole section has been deleted but the event is still up
           if (!sessionFound) {
             return seneca.act({role: plugin, cmd: 'cancelSession', session: existingSession, locality: locality, user: user}, cb);
           } else {


### PR DESCRIPTION
By not using variable replacement but appending value (session name) the string was faulty and couldn't be translated, which resulted in a email not being sent.
Fixed it as well as the "default" translation when a session is removed from an existing published event, a thing we shouldn't even do, but eh.
Requires https://github.com/CoderDojo/cp-translations/pull/7