### PR TITLE
Add constraint to stop fast webhooks from creating 2 events with…

### DIFF
--- a/scripts/database/pg/migrations/020.do.add-constraint-unique-eventbrite-event-id.sql
+++ b/scripts/database/pg/migrations/020.do.add-constraint-unique-eventbrite-event-id.sql
@@ -1,0 +1,9 @@
+DO $$
+  BEGIN
+    BEGIN
+        ALTER TABLE cd_events ADD UNIQUE (eventbrite_id);
+    EXCEPTION
+        WHEN duplicate_column THEN RAISE NOTICE 'constraint eventbrite_id already exists in cd_events.';
+    END;
+  END;
+$$

--- a/scripts/database/pg/migrations/020.do.add-constraint-unique-eventbrite-event-id.sql
+++ b/scripts/database/pg/migrations/020.do.add-constraint-unique-eventbrite-event-id.sql
@@ -3,7 +3,7 @@ DO $$
     BEGIN
         ALTER TABLE cd_events ADD UNIQUE (eventbrite_id);
     EXCEPTION
-        WHEN duplicate_column THEN RAISE NOTICE 'constraint eventbrite_id already exists in cd_events.';
+        WHEN OTHERS THEN RAISE NOTICE 'constraint eventbrite_id already exists in cd_events.';
     END;
   END;
 $$


### PR DESCRIPTION
… the same eb_id and then breaking the update process.
**NB** : DO NOT merge until we clean up existing with duplicates or the event microservice is good for an infinite loop of restart 