### PR TITLE
Add migrations to enable new event form functionality

### DIFF
--- a/scripts/database/pg/migrations/028.do.add-event-new-form-flag.sql
+++ b/scripts/database/pg/migrations/028.do.add-event-new-form-flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cd_events ADD column new_form BOOLEAN DEFAULT FALSE;

--- a/scripts/database/pg/migrations/029.do.update-event-occurrences-view.sql
+++ b/scripts/database/pg/migrations/029.do.update-event-occurrences-view.sql
@@ -1,0 +1,12 @@
+DO $$
+  BEGIN
+    DROP VIEW v_event_occurrences;
+    CREATE OR REPLACE VIEW v_event_occurrences AS (
+      SELECT id, name, country, city, address, created_at, created_by, type, description, dojo_id, position, public,
+      status, recurring_type, dates, ticket_approval, notify_on_applicant, eventbrite_id, eventbrite_url, use_dojo_address,
+      start_time::timestamp, end_time::timestamp, new_form FROM (
+        SELECT *, unnest(dates)->>'startTime' as start_time, unnest(dates)->>'endTime' as end_time FROM cd_events
+      ) x WHERE start_time IS NOT NULL AND start_time NOT LIKE 'Invalid%' AND end_time IS NOT NULL AND end_time NOT LIKE 'Invalid%'
+    );
+  END;
+$$


### PR DESCRIPTION
Adds a 'new_form' flag to the events table.
This will allow us to send users to the correct page for editing an event depending on which page was used to create it.

This will also allow us to determine uptake of the new form.